### PR TITLE
image_builder: fix: disable dtparam in chroot

### DIFF
--- a/image_builder/scripts/hardware_setup.sh
+++ b/image_builder/scripts/hardware_setup.sh
@@ -12,6 +12,10 @@ set -e
 # Configure hardware interfaces
 ##################################################
 
+# Disable dtparam in chroot (use in raspi-config)
+echo "echo 'dtparam is disabled in chroot'" >> /root/dtparam && chmod +x /root/dtparam
+export PATH=/root:$PATH
+
 # 1. Enable sshd
 echo -e "\033[0;31m\033[1m$(date) | #1 Turn on sshd\033[0m\033[0m"
 touch /boot/ssh
@@ -38,5 +42,7 @@ echo -e "\033[0;31m\033[1m$(date) | #6 Turn on v4l2 driver\033[0m\033[0m"
 if ! grep -q "^bcm2835-v4l2" /etc/modules;
 then printf "bcm2835-v4l2\n" >> /etc/modules
 fi
+
+rm /root/dtparam
 
 echo -e "\033[0;31m\033[1m$(date) | End of configure hardware interfaces\033[0m\033[0m"


### PR DESCRIPTION
After replacement https://github.com/CopterExpress/clever/commit/0346c48546590faa00f7ee0a1d0ea71f6343bd17 our forked-scripts to `raspi-config` I meet problem that `raspi-config` not correct work in chroot.

And now I made hack to replace `dtparam` to stopper script.
P.S. After next session `PATH` is become normal. And script self-removed.

Any ideas?

More information you can find there https://github.com/CopterExpress/clever/issues/38