### PR TITLE
image_buider: enable hardware uart with raspi-config

### DIFF
--- a/image_builder/scripts/hardware_setup.sh
+++ b/image_builder/scripts/hardware_setup.sh
@@ -32,11 +32,22 @@ echo -e "\033[0;31m\033[1m$(date) | #4 Turn on SPI\033[0m\033[0m"
 echo -e "\033[0;31m\033[1m$(date) | #5 Turn on raspicam\033[0m\033[0m"
 /usr/bin/raspi-config nonint do_camera 0
 
-# 6. Enable V4L driver http://robocraft.ru/blog/electronics/3158.html
+# 6. Enable hardware UART
+echo -e "\033[0;31m\033[1m$(date) | #6 Turn on UART\033[0m\033[0m"
+# Temporary solution
+# https://github.com/RPi-Distro/raspi-config/pull/75
+/usr/bin/raspi-config nonint do_serial 1
+/usr/bin/raspi-config nonint set_config_var enable_uart 1 /boot/config.txt
+
+# After adding to Raspbian OS
+# https://github.com/RPi-Distro/raspi-config/commit/d6d9ecc0d9cbe4aaa9744ae733b9cb239e79c116
+#/usr/bin/raspi-config nonint do_serial 2
+
+# 7. Enable V4L driver http://robocraft.ru/blog/electronics/3158.html
 #echo "bcm2835-v4l2" >> /etc/modules
-echo -e "\033[0;31m\033[1m$(date) | #6 Turn on v4l2 driver\033[0m\033[0m"
-if ! grep -q "^bcm2835-v4l2" /etc/modules; then
-  printf "bcm2835-v4l2\n" >> /etc/modules
+echo -e "\033[0;31m\033[1m$(date) | #7 Turn on v4l2 driver\033[0m\033[0m"
+if ! grep -q "^bcm2835-v4l2" /etc/modules;
+then printf "bcm2835-v4l2\n" >> /etc/modules
 fi
 
 echo -e "\033[0;31m\033[1m$(date) | End of configure hardware interfaces\033[0m\033[0m"


### PR DESCRIPTION
Now, in image doesn't work hardware UART. About this problem there https://github.com/CopterExpress/clever/issues/41.

After replace https://github.com/CopterExpress/clever/commit/0346c48546590faa00f7ee0a1d0ea71f6343bd17 our [forked scripts](
https://github.com/CopterExpress/clever/blob/v0.4/image_builder/scripts/hardware_setup.sh) to `raspi-config`, I can't turn on only HW interface wo user console on this version of `raspi-config`. But I found solution there https://github.com/RPi-Distro/raspi-config/pull/75.

**Next, after adding this commit https://github.com/RPi-Distro/raspi-config/commit/d6d9ecc0d9cbe4aaa9744ae733b9cb239e79c116 to official Raspbian OS release we can use**:
```(bash)
/usr/bin/raspi-config nonint do_serial 2
```

More information you can find there https://github.com/CopterExpress/clever/issues/38