### PR TITLE
Improve copyright notices

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Copter Express
+Copyright (c) 2018 Copter Express Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/ios/cleverrc/AppDelegate.swift
+++ b/apps/ios/cleverrc/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  cleverrc
 //
 //  Created by Oleg Kalachev on 20.01.2018.
-//  Copyright © 2018 Copter Express. All rights reserved.
+//  Copyright © 2018 Copter Express Technologies. All rights reserved.
 //
 
 import UIKit

--- a/apps/ios/cleverrc/ViewController.swift
+++ b/apps/ios/cleverrc/ViewController.swift
@@ -3,7 +3,7 @@
 //  cleverrc
 //
 //  Created by Oleg Kalachev on 20.01.2018.
-//  Copyright © 2018 Copter Express. All rights reserved.
+//  Copyright © 2018 Copter Express Technologies. All rights reserved.
 //
 
 import UIKit

--- a/clever/src/camera_markers.cpp
+++ b/clever/src/camera_markers.cpp
@@ -4,7 +4,9 @@
  *
  * Author: Oleg Kalachev <okalachev@gmail.com>
  *
- * Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ * Distributed under MIT License (available at https://opensource.org/licenses/MIT).
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  */
 
 #include <string>

--- a/clever/src/optical_flow.cpp
+++ b/clever/src/optical_flow.cpp
@@ -4,7 +4,9 @@
  *
  * Author: Oleg Kalachev <okalachev@gmail.com>
  *
- * Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ * Distributed under MIT License (available at https://opensource.org/licenses/MIT).
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  */
 
 #include <vector>


### PR DESCRIPTION
Usually the full MIT license text is used in headers but it's quite long. Here I made it as short as possible: 
```c++
/*
 * Visualization marker for camera alignment
 * Copyright © 2018 Copter Express Technologies
 *
 * Author: Oleg Kalachev <okalachev@gmail.com>
 *
 * Distributed under MIT License (available at https://opensource.org/licenses/MIT).
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
 */
```
One of the possible alternatives:
```c++
/*
 * Visualization marker for camera alignment
 * Copyright © 2018 Copter Express Technologies
 *
 * Author: Oleg Kalachev <okalachev@gmail.com>
 *
 * Distributed under MIT License. If a copy of the MIT License was not distributed
 * with this file, you can obtain one at https://opensource.org/licenses/MIT.
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
 */
```