### PR TITLE
Build script fixes

### DIFF
--- a/builder/image-software.sh
+++ b/builder/image-software.sh
@@ -106,11 +106,13 @@ monkey=1.6.9-1 \
 sed -i "s/updates_available//" /usr/share/byobu/status/status
 # sed -i "s/updates_available//" /home/pi/.byobu/status
 
-echo_stamp "Upgrade pip"
-my_travis_retry pip install --upgrade pip
-my_travis_retry python3 -m pip install --upgrade pip
+#echo_stamp "Upgrade pip"
+#my_travis_retry pip install --upgrade pip
+#my_travis_retry pip3 install --upgrade pip
 
-echo_stamp "Make sure both pip and pip3 are installed and upgraded"
+echo_stamp "Not upgrading system pip due to https://github.com/pypa/pip/issues/5599"
+
+echo_stamp "Make sure both pip and pip3 are installed"
 pip --version
 pip3 --version
 

--- a/builder/image-software.sh
+++ b/builder/image-software.sh
@@ -108,7 +108,11 @@ sed -i "s/updates_available//" /usr/share/byobu/status/status
 
 echo_stamp "Upgrade pip"
 my_travis_retry pip install --upgrade pip
-my_travis_retry pip3 install --upgrade pip3
+my_travis_retry python3 -m pip install --upgrade pip
+
+echo_stamp "Make sure both pip and pip3 are installed and upgraded"
+pip --version
+pip3 --version
 
 echo_stamp "Install and enable Butterfly (web terminal)"
 my_travis_retry pip3 install butterfly


### PR DESCRIPTION
Right now the build system attempts to upgrade pip system-wide. This fails for several reasons:

 * ```pip3``` seems to no longer exist in [PyPI](https://pypi.org/search/?q=pip3)

 * Debian uses an unsupported API for pip (https://github.com/pypa/pip/issues/5240, https://github.com/pypa/pip/issues/5221)

 * Upgrading pip system-wide through pip itself is generally frowned upon (https://github.com/pypa/pip/issues/5599), it's a task for the system package manager

 * Not entirely related, but ```pip``` now refers to ```pip3``` by default

This PR disables upgrading pip system-wide. End users should be able to upgrade pip in their virtual environments and/or on a per user basis.