### PR TITLE
Remove unused arguments from sitl.launch

### DIFF
--- a/clever/launch/mavros.launch
+++ b/clever/launch/mavros.launch
@@ -13,7 +13,7 @@
         <param name="fcu_url" value="/dev/ttyACM0" if="$(eval fcu_conn == 'usb')"/>
 
         <!-- sitl -->
-        <param name="fcu_url" value="udp://@$(arg fcu_ip):14557" if="$(eval fcu_conn == 'udp')"/>
+        <param name="fcu_url" value="udp://:14540@$(arg fcu_ip):14557" if="$(eval fcu_conn == 'udp')"/>
 
         <!-- gcs bridge -->
         <param name="gcs_url" value="tcp-l://0.0.0.0:5760" if="$(eval gcs_bridge == 'tcp')"/>

--- a/clever/launch/sitl.launch
+++ b/clever/launch/sitl.launch
@@ -12,7 +12,7 @@
         <arg name="main_camera" default="false"/>
         <arg name="rosbridge" value="$(arg rosbridge)"/>
         <arg name="aruco" default="false"/>
-	<arg name="rangefinder_vl53l1x" default="false"/>
+        <arg name="rangefinder_vl53l1x" default="false"/>
         <arg name="rc" default="false"/>
     </include>
 </launch>

--- a/clever/launch/sitl.launch
+++ b/clever/launch/sitl.launch
@@ -8,12 +8,10 @@
         <arg name="fcu_ip" value="$(arg ip)"/>
         <arg name="gcs_bridge" value="false"/>
         <arg name="optical_flow" value="false"/>
-        <arg name="web_server" default="false"/>
         <arg name="web_video_server" default="false"/>
         <arg name="main_camera" default="false"/>
         <arg name="rosbridge" value="$(arg rosbridge)"/>
         <arg name="aruco" default="false"/>
-        <arg name="vl53l1x" default="false"/>
         <arg name="rc" default="false"/>
     </include>
 </launch>

--- a/clever/launch/sitl.launch
+++ b/clever/launch/sitl.launch
@@ -12,6 +12,7 @@
         <arg name="main_camera" default="false"/>
         <arg name="rosbridge" value="$(arg rosbridge)"/>
         <arg name="aruco" default="false"/>
+	<arg name="rangefinder_vl53l1x" default="false"/>
         <arg name="rc" default="false"/>
     </include>
 </launch>


### PR DESCRIPTION
ROS doesn't like unused arguments in launchfiles; this PR simply removes them from the sitl.launch file.