### PR TITLE
build: Kill dirmngr before unmounting chroot

### DIFF
--- a/builder/image-software.sh
+++ b/builder/image-software.sh
@@ -138,4 +138,7 @@ syntax on
 autocmd BufNewFile,BufRead *.launch set syntax=xml
 EOF
 
+echo_stamp "Attempting to kill dirmngr"
+gpgconf --kill dirmngr
+
 echo_stamp "End of software installation"


### PR DESCRIPTION
```dirmngr``` is preventing us from unmounting the image properly. It should not be running in a chrooted environment, especially after the script exits from one, but our interactions with ```systemctl``` might start it as a service.

This P/R attempts to stop ```dirmngr``` service so that the image could be unmounted cleanly.

I don't expect this to fix all builds, there might be other issues elsewhere.