### PR TITLE
build: Update python-rosdep to 0.14.0

### DIFF
--- a/builder/image-software.sh
+++ b/builder/image-software.sh
@@ -92,7 +92,7 @@ libjpeg8-dev=8d1-2 \
 tcpdump \
 ltrace \
 libpoco-dev=1.7.6+dfsg1-5+deb9u1 \
-python-rosdep=0.13.0-1 \
+python-rosdep=0.14.0-1 \
 python-rosinstall-generator=0.1.14-1 \
 python-wstool=0.1.17-1 \
 python-rosinstall=0.7.8-1 \


### PR DESCRIPTION
python-rosdep 0.13.0 was removed from Raspbian repositories, breaking our build.

[Changelog](https://github.com/ros-infrastructure/rosdep/blob/master/CHANGELOG.rst) seems innocent enough, should be a trivial fix. Using a more recent rosdep should have an added benefit of ignoring ROS distros that we don't care about.