### PR TITLE
ROS: Use ROS_HOSTNAME instead of ROS_IP

### DIFF
--- a/builder/assets/roscore.env
+++ b/builder/assets/roscore.env
@@ -7,4 +7,4 @@ CMAKE_PREFIX_PATH=/home/pi/catkin_ws/devel:/opt/ros/kinetic
 PATH=/opt/ros/kinetic/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
 LD_LIBRARY_PATH=/opt/ros/kinetic/lib
 PYTHONPATH=/home/pi/catkin_ws/devel/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages
-ROS_IP=192.168.11.1
+ROS_HOSTNAME=raspberrypi.local

--- a/builder/image-ros.sh
+++ b/builder/image-ros.sh
@@ -180,7 +180,7 @@ cat << EOF >> /home/pi/.bashrc
 LANG='C.UTF-8'
 LC_ALL='C.UTF-8'
 ROS_DISTRO='kinetic'
-export ROS_IP='192.168.11.1'
+export ROS_HOSTNAME='raspberrypi.local'
 source /opt/ros/kinetic/setup.bash
 source /home/pi/catkin_ws/devel/setup.bash
 EOF

--- a/clever/launch/mavros.launch
+++ b/clever/launch/mavros.launch
@@ -18,8 +18,8 @@
         <!-- gcs bridge -->
         <param name="gcs_url" value="tcp-l://0.0.0.0:5760" if="$(eval gcs_bridge == 'tcp')"/>
         <param name="gcs_url" value="udp://0.0.0.0:14550@14550" if="$(eval gcs_bridge == 'udp')"/>
-        <param name="gcs_url" value="udp-b://$(env ROS_IP):14550@14550" if="$(eval gcs_bridge == 'udp-b')"/>
-        <param name="gcs_url" value="udp-pb://$(env ROS_IP):14550@14550" if="$(eval gcs_bridge == 'udp-pb')"/>
+        <param name="gcs_url" value="udp-b://$(env ROS_HOSTNAME):14550@14550" if="$(eval gcs_bridge == 'udp-b')"/>
+        <param name="gcs_url" value="udp-pb://$(env ROS_HOSTNAME):14550@14550" if="$(eval gcs_bridge == 'udp-pb')"/>
         <param name="gcs_url" value="" if="$(eval not gcs_bridge)"/>
         <param name="gcs_quiet_mode" value="true"/>
         <param name="conn/timeout" value="8"/>

--- a/docs/ru/rviz.md
+++ b/docs/ru/rviz.md
@@ -23,7 +23,7 @@ ROS_MASTER_URI=http://192.168.11.1:11311 rviz
 Если соединение не устанавливается, необходимо убедиться, что в `.bashrc` Клевера присутствует строка:
 
 ```bash
-export ROS_IP=192.168.11.1
+export ROS_HOSTNAME=raspberrypi.local
 ```
 
 Использование rviz


### PR DESCRIPTION
This should allow us to access Clever nodes by hostname as well as its IP address. This may have an added benefit of working over different network configurations.