### PR TITLE
Use official Raspbian mirror, cache downloaded image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,16 @@ matrix:
   fast_finish: true
   include:
     - name: "Raspberry Pi Image Build"
+      cache:
+        directories:
+        - imgcache
       before_script:
         - docker pull ${DOCKER}
+        - if [ -d imgcache ]; then mkdir -p images && cp imgcache/*.zip images; fi
       script:
         - docker run --privileged --rm -v /dev:/dev -v $(pwd):/builder/repo -e TRAVIS_TAG="${TRAVIS_TAG}" ${DOCKER}
+      before_cache:
+        - cp images/*.zip imgcache
       before_deploy:
         # Set up git user name and tag this commit
         - git config --local user.name "goldarte"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ matrix:
         - imgcache
       before_script:
         - docker pull ${DOCKER}
-        - if [ -d imgcache ]; then mkdir -p images && cp imgcache/*.zip images; fi
+# Check if there are any cached images, copy them to our "images" directory
+        - if [ -n "$(ls -A imgcache/*.zip)" ]; then mkdir -p images && cp imgcache/*.zip images; fi
       script:
         - docker run --privileged --rm -v /dev:/dev -v $(pwd):/builder/repo -e TRAVIS_TAG="${TRAVIS_TAG}" ${DOCKER}
       before_cache:

--- a/builder/image-build.sh
+++ b/builder/image-build.sh
@@ -11,7 +11,7 @@
 
 set -e # Exit immidiately on non-zero result
 
-SOURCE_IMAGE="http://repo.coex.space/2018-06-27-raspbian-stretch-lite.zip"
+SOURCE_IMAGE="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-06-29/2018-06-27-raspbian-stretch-lite.zip"
 
 export DEBIAN_FRONTEND=${DEBIAN_FRONTEND:='noninteractive'}
 export LANG=${LANG:='C.UTF-8'}

--- a/builder/image-build.sh
+++ b/builder/image-build.sh
@@ -59,10 +59,9 @@ get_image() {
   local RPI_IMAGE_NAME=$(echo ${RPI_ZIP_NAME} | sed 's/zip/img/')
 
   if [ ! -e "${BUILD_DIR}/${RPI_ZIP_NAME}" ]; then
-    echo_stamp "Downloading original Linux distribution" \
-    && wget -nv -O ${BUILD_DIR}/${RPI_ZIP_NAME} $2 \
-    && echo_stamp "Downloading complete" "SUCCESS" \
-    || (echo_stamp "Downloading was failed!" "ERROR"; exit 1)
+    echo_stamp "Downloading original Linux distribution"
+    wget --progress=bar:force:noscroll -O ${BUILD_DIR}/${RPI_ZIP_NAME} $2
+    echo_stamp "Downloading complete" "SUCCESS" \
   else echo_stamp "Linux distribution already donwloaded"; fi
 
   echo_stamp "Unzipping Linux distribution image" \

--- a/builder/image-build.sh
+++ b/builder/image-build.sh
@@ -60,7 +60,7 @@ get_image() {
 
   if [ ! -e "${BUILD_DIR}/${RPI_ZIP_NAME}" ]; then
     echo_stamp "Downloading original Linux distribution"
-    wget --progress=bar:force:noscroll -O ${BUILD_DIR}/${RPI_ZIP_NAME} $2
+    wget --progress=dot:giga -O ${BUILD_DIR}/${RPI_ZIP_NAME} $2
     echo_stamp "Downloading complete" "SUCCESS" \
   else echo_stamp "Linux distribution already donwloaded"; fi
 


### PR DESCRIPTION
Some of our builds have failed because initial Raspbian image download took too long. Curiously enough, downloading from the official mirror sometimes fails as well, but should probably be a little more stable.

Still, we could also use Travis cache, since our base image tends to not change as often. This P/R does this as well.