### PR TITLE
Echo executing commands in builder

### DIFF
--- a/builder/image-build.sh
+++ b/builder/image-build.sh
@@ -10,6 +10,7 @@
 #
 
 set -e # Exit immidiately on non-zero result
+set -v # Echo commands
 
 SOURCE_IMAGE="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-11-15/2018-11-13-raspbian-stretch-lite.zip"
 

--- a/builder/image-init.sh
+++ b/builder/image-init.sh
@@ -9,6 +9,7 @@
 #
 
 set -e # Exit immidiately on non-zero result
+set -v # Echo commands
 
 echo_stamp() {
   # TEMPLATE: echo_stamp <TEXT> <TYPE>

--- a/builder/image-network.sh
+++ b/builder/image-network.sh
@@ -9,6 +9,7 @@
 #
 
 set -e # Exit immidiately on non-zero result
+set -v # Echo commands
 
 echo_stamp() {
   # TEMPLATE: echo_stamp <TEXT> <TYPE>

--- a/builder/image-ros.sh
+++ b/builder/image-ros.sh
@@ -10,6 +10,7 @@
 #
 
 set -e # Exit immidiately on non-zero result
+set -v # Echo commands
 
 REPO=$1
 REF=$2

--- a/builder/image-software.sh
+++ b/builder/image-software.sh
@@ -9,6 +9,7 @@
 #
 
 set -e # Exit immidiately on non-zero result
+set -v # Echo commands
 
 echo_stamp() {
   # TEMPLATE: echo_stamp <TEXT> <TYPE>


### PR DESCRIPTION
Сделать сборщик более вербозным, чтобы было понятно, какие конкретно команды что выдают / какие падают с ошибкой.

Минусы: `echo` будут выводиться по 2 раза. Возможно, еще какие-нибудь.