### PR TITLE
Fast docs rebuild (for pull requests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         - if [[ -z ${TRAVIS_TAG} && ${TRAVIS_PULL_REQUEST} ]]; then
             echo "Commit range is ${TRAVIS_COMMIT_RANGE}" &&
             if [ $(git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -v ^"docs/" | wc -l) -eq 0 ]; then
-              echo "Docs-only change; skipping build" &&
+              echo " === Docs-only change; skipping build ===" &&
               export SKIP_BUILD=true;
             fi;
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ jobs:
 # Check if there are any cached images, copy them to our "images" directory
         - if [ -n "$(ls -A imgcache/*.zip)" ]; then mkdir -p images && cp imgcache/*.zip images; fi
       script:
-        - if [[ -z ${TRAVIS_TAG} && ${TRAVIS_PULL_REQUEST} ]]; then \
-            echo "Commit range is ${TRAVIS_COMMIT_RANGE}" && \
-            if [ $(git diff --name-only ${TRAVIS_COMMIT_RANGE} && grep -v docs | wc -l) -eq 0 ]; then \
-              echo "Docs-only change; skipping build" && \
-              export SKIP_BUILD=true; \
-            fi; \
+        - if [[ -z ${TRAVIS_TAG} && ${TRAVIS_PULL_REQUEST} ]]; then
+            echo "Commit range is ${TRAVIS_COMMIT_RANGE}" &&
+            if [ $(git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -v docs | wc -l) -eq 0 ]; then
+              echo "Docs-only change; skipping build" &&
+              export SKIP_BUILD=true;
+            fi;
           fi
-        - if [ -z ${SKIP_BUILD} ]; then \
-            docker run --privileged --rm -v /dev:/dev -v $(pwd):/builder/repo -e TRAVIS_TAG="${TRAVIS_TAG}" ${DOCKER}; \
+        - if [ -z ${SKIP_BUILD} ]; then
+            docker run --privileged --rm -v /dev:/dev -v $(pwd):/builder/repo -e TRAVIS_TAG="${TRAVIS_TAG}" ${DOCKER};
           fi
       before_cache:
         - cp images/*.zip imgcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,16 @@ jobs:
 # Check if there are any cached images, copy them to our "images" directory
         - if [ -n "$(ls -A imgcache/*.zip)" ]; then mkdir -p images && cp imgcache/*.zip images; fi
       script:
-        - docker run --privileged --rm -v /dev:/dev -v $(pwd):/builder/repo -e TRAVIS_TAG="${TRAVIS_TAG}" ${DOCKER}
+        - if [[ -z ${TRAVIS_TAG} && ${TRAVIS_PULL_REQUEST} ]]; then \
+            echo "Commit range is ${TRAVIS_COMMIT_RANGE}" && \
+            if [ $(git diff --name-only ${TRAVIS_COMMIT_RANGE} && grep -v docs | wc -l) -eq 0 ]; then \
+              echo "Docs-only change; skipping build" && \
+              export SKIP_BUILD=true; \
+            fi; \
+          fi
+        - if [ -z ${SKIP_BUILD} ]; then \
+            docker run --privileged --rm -v /dev:/dev -v $(pwd):/builder/repo -e TRAVIS_TAG="${TRAVIS_TAG}" ${DOCKER}; \
+          fi
       before_cache:
         - cp images/*.zip imgcache
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       script:
         - if [[ -z ${TRAVIS_TAG} && ${TRAVIS_PULL_REQUEST} ]]; then
             echo "Commit range is ${TRAVIS_COMMIT_RANGE}" &&
-            if [ $(git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -v docs | wc -l) -eq 0 ]; then
+            if [ $(git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -v ^"docs/" | wc -l) -eq 0 ]; then
               echo "Docs-only change; skipping build" &&
               export SKIP_BUILD=true;
             fi;


### PR DESCRIPTION
Some pull requests contain changes for our documentation only. These pull requests may and should be processed quickly: the build should only fail for them if they don't pass linting.

This pull request disables building the whole image for pull requests that only contain changes for docs. This should result in a better user experience for documentation contributors, cutting the response time from our CI from an hour to a couple of minutes.