### PR TITLE
Add workaround for avahi not working on loopback interfaces

### DIFF
--- a/builder/assets/clever_rename
+++ b/builder/assets/clever_rename
@@ -11,8 +11,11 @@ if [[ -z ${NEW_NAME_OPT} ]]; then
   exit 1
 fi
 
+# Get old hostname from /etc/hostname - we might have a different hostname for this session
+OLD_NAME=$(cat /etc/hostname | tr -d '[:space:]')
 NEW_NAME=$(echo ${NEW_NAME_OPT} | tr '[:upper:]' '[:lower:]')
 
+echo "Old name is ${OLD_NAME}"
 echo "Setting name to ${NEW_NAME}"
 
 echo "Backing up /etc/hostname"
@@ -23,7 +26,7 @@ echo ${NEW_NAME} > /etc/hostname
 echo "Backing up /etc/hosts"
 cp /etc/hosts /etc/hosts.bak
 echo "Rewriting /etc/hosts with new values"
-sed -i 's/127\.0\.1\.1.*/127.0.1.1\t'${NEW_NAME}'/g' /etc/hosts
+sed -i 's/127\.0\.1\.1.+'${OLD_NAME}'/127.0.1.1\t'${NEW_NAME}'/g' /etc/hosts
 
 echo "Changing hostname in /lib/systemd/system/roscore.env"
 sed -i 's/ROS_HOSTNAME=.*/ROS_HOSTNAME='${NEW_NAME}'.local/g' /lib/systemd/system/roscore.env

--- a/builder/image-network.sh
+++ b/builder/image-network.sh
@@ -74,4 +74,7 @@ EOF
 #RENAME_SSID="sudo sed -i.OLD \"s/CLEVER/CLEVER-\$(head -c 100 /dev/urandom | xxd -ps -c 100 | sed -e 's/[^0-9]//g' | cut -c 1-4)/g\" /etc/wpa_supplicant/wpa_supplicant.conf && sudo sed -i '/sudo sed/d' /etc/rc.local && sudo reboot"
 #sed -i "19a$RENAME_SSID" /etc/rc.local
 
+echo_stamp "Add raspberrypi.local to /etc/hosts"
+printf '127.0.1.1\traspberrypi.local\n' >> /etc/hosts
+
 echo_stamp "#5 End of network installation"


### PR DESCRIPTION
As of now, avahi doesn't work with loopback interfaces. This results in Clever ROS nodes being unable to communicate with ROS master, even though they are all running locally.

This adds a workaround for this problem, placing a record for &lt;hostname&gt;.local in /etc/hosts. This does not sound like a good solution (a better one would be to make Clever resolvable by its hostname on every network, but so far I couldn't find a way to do that reliably).