### PR TITLE
Show roslaunch errors in selfcheck

### DIFF
--- a/builder/assets/clever.service
+++ b/builder/assets/clever.service
@@ -7,8 +7,6 @@ After=network.target
 User=pi
 ExecStart=/bin/sh -c ". /home/pi/catkin_ws/devel/setup.sh; \
                       ROS_HOSTNAME=`hostname`.local exec roslaunch clever clever.launch --wait --screen --skip-log-check"
-Restart=on-failure
-RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/clever/src/selfcheck.py
+++ b/clever/src/selfcheck.py
@@ -642,16 +642,18 @@ def check_clever_service():
     j.add_match(UNIT='clever.service')
     node_errors = []
     r = re.compile(r'^(.*)\[(FATAL|ERROR)\] \[\d+.\d+\]: (.*)$')
-    for event in j:
+    for event in reversed(list(j)):
         msg = event['MESSAGE']
-        if ('Stopped Clever ROS package' in msg) or ('Started Clever ROS package' in msg):
-            node_errors = []
+        if 'Started Clever ROS package' in msg:
+            break  # we're done
         elif ('[ERROR]' in msg) or ('[FATAL]' in msg):
             msg = r.search(msg).groups()[2]
             if msg in node_errors:
                 continue
             node_errors.append(msg)
-    for error in node_errors:
+        elif ('ERROR: ' in msg) or ('while processing' in msg) or ('Invalid roslaunch XML syntax' in msg):
+            node_errors.append(msg)
+    for error in reversed(node_errors):
         failure(error)
 
 


### PR DESCRIPTION
* Remove `clever.service` auto-restart. Roslaunch is unlikely to fail on reason not related to launch-file errors.
* Simplify service check in selfcheck.py. Show roslaunch errors.