### PR TITLE
clever.service: Add line buffering

### DIFF
--- a/builder/assets/clever.service
+++ b/builder/assets/clever.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 User=pi
 ExecStart=/bin/bash -c ". /home/pi/catkin_ws/devel/setup.sh; \
-                      ROS_HOSTNAME=`hostname`.local exec roslaunch clever clever.launch --wait --screen --skip-log-check \
+                      ROS_HOSTNAME=`hostname`.local exec stdbuf -o L roslaunch clever clever.launch --wait --screen --skip-log-check \
                       2> >(tee /tmp/clever.err)"
 
 [Install]


### PR DESCRIPTION
Currently nodes may interfere with each other's output streams, resulting in mangled lines and unreadable logs. This P/R addresses that, adding line buffering to `roslaunch` output.