### PR TITLE
launch: change default led node status

### DIFF
--- a/clever/launch/clever.launch
+++ b/clever/launch/clever.launch
@@ -8,7 +8,7 @@
     <arg name="optical_flow" default="false"/>
     <arg name="aruco" default="false"/>
     <arg name="rangefinder_vl53l1x" default="false"/>
-    <arg name="led" default="false"/>
+    <arg name="led" default="true"/>
     <arg name="rc" default="true"/>
 
     <!-- log formatting -->

--- a/clever/launch/led.launch
+++ b/clever/launch/led.launch
@@ -9,7 +9,7 @@
     <node pkg="ws281x" name="led" type="ws281x_node" clear_params="true" output="screen" if="$(arg ws281x)">
         <param name="led_count" value="58"/>
         <param name="gpio_pin" value="21"/>
-        <param name="brightness" value="100"/>
+        <param name="brightness" value="64"/>
         <param name="strip_type" value="WS2811_STRIP_GRB"/>
         <param name="target_frequency" value="800000"/>
         <param name="dma" value="10"/>


### PR DESCRIPTION
We can by default set the value of the LED strip node to true. Since the LED strip does not give any feedback, everything will work correctly, even if it is not connected.