### PR TITLE
Limit syslog size

### DIFF
--- a/builder/assets/rsyslog.conf
+++ b/builder/assets/rsyslog.conf
@@ -53,18 +53,18 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 #
 # Enable custom output channels to limit file sizes
 #
-$outchannel limauth,/var/log/auth.log,10485760
-$outchannel limsyslog,/var/log/syslog,10485760
-$outchannel limdaemon,/var/log/daemon.log,10485760
-$outchannel limkern,/var/log/kern.log,10485760
-$outchannel limlpr,/var/log/lpr.log,10485760
-$outchannel limmail,/var/log/mail.log,10485760
-$outchannel limmailinfo,/var/log/mail.info,10485760
-$outchannel limmailwarn,/var/log/mail.warn,10485760
-$outchannel limmailerr,/var/log/mail.err,10485760
-$outchannel limuser,/var/log/user.log,10485760
-$outchannel limdebug,/var/log/debug,10485760
-$outchannel limmsgs,/var/log/messages,10485760
+$outchannel limauth,/var/log/auth.log,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/auth.log
+$outchannel limsyslog,/var/log/syslog,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/syslog
+$outchannel limdaemon,/var/log/daemon.log,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/daemon.log
+$outchannel limkern,/var/log/kern.log,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/kern.log
+$outchannel limlpr,/var/log/lpr.log,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/lpr.log
+$outchannel limmail,/var/log/mail.log,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/mail.log
+$outchannel limmailinfo,/var/log/mail.info,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/mail.info
+$outchannel limmailwarn,/var/log/mail.warn,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/mail.warn
+$outchannel limmailerr,/var/log/mail.err,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/mail.err
+$outchannel limuser,/var/log/user.log,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/user.log
+$outchannel limdebug,/var/log/debug,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/debug
+$outchannel limmsgs,/var/log/messages,10485760,/etc/rsyslog.d/rsysrot.sh /var/log/messages
 
 ###############
 #### RULES ####

--- a/builder/assets/rsyslog.conf
+++ b/builder/assets/rsyslog.conf
@@ -1,0 +1,107 @@
+# /etc/rsyslog.conf configuration file for rsyslog
+#
+# For more information install rsyslog-doc and see
+# /usr/share/doc/rsyslog-doc/html/configuration/index.html
+
+
+#################
+#### MODULES ####
+#################
+
+module(load="imuxsock") # provides support for local system logging
+module(load="imklog")   # provides kernel logging support
+#module(load="immark")  # provides --MARK-- message capability
+
+# provides UDP syslog reception
+#module(load="imudp")
+#input(type="imudp" port="514")
+
+# provides TCP syslog reception
+#module(load="imtcp")
+#input(type="imtcp" port="514")
+
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+#
+# Enable custom output channels to limit file sizes
+#
+$outchannel limauth,/var/log/auth.log,10485760
+$outchannel limsyslog,/var/log/syslog,10485760
+$outchannel limdaemon,/var/log/daemon.log,10485760
+$outchannel limkern,/var/log/kern.log,10485760
+$outchannel limlpr,/var/log/lpr.log,10485760
+$outchannel limmail,/var/log/mail.log,10485760
+$outchannel limmailinfo,/var/log/mail.info,10485760
+$outchannel limmailwarn,/var/log/mail.warn,10485760
+$outchannel limmailerr,/var/log/mail.err,10485760
+$outchannel limuser,/var/log/user.log,10485760
+$outchannel limdebug,/var/log/debug,10485760
+$outchannel limmsgs,/var/log/messages,10485760
+
+###############
+#### RULES ####
+###############
+
+#
+# First some standard log files.  Log by facility.
+#
+auth,authpriv.*			:omfile:$limauth
+*.*;auth,authpriv.none		:omfile:$limsyslog
+#cron.*				/var/log/cron.log
+daemon.*			:omfile:$limdaemon
+kern.*				:omfile:$limkern
+lpr.*				:omfile:$limlpr
+mail.*				:omfile:$limmail
+user.*				:omfile:$limuser
+
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+mail.info			:omfile:$limmailinfo
+mail.warn			:omfile:$limmailwarn
+mail.err			:omfile:$limmailerr
+
+#
+# Some "catch-all" log files.
+#
+*.=debug;\
+	auth,authpriv.none;\
+	news.none;mail.none	:omfile:$limdebug
+*.=info;*.=notice;*.=warn;\
+	auth,authpriv.none;\
+	cron,daemon.none;\
+	mail,news.none		:omfile:$limmsgs
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg				:omusrmsg:*

--- a/builder/assets/rsyslog.conf
+++ b/builder/assets/rsyslog.conf
@@ -46,6 +46,12 @@ $Umask 0022
 $WorkDirectory /var/spool/rsyslog
 
 #
+# Limit log to 40 messages per second on average (should be plenty)
+#
+$SystemLogRateLimitInterval 5
+$SystemLogRateLimitBurst 200
+
+#
 # Include all config files in /etc/rsyslog.d/
 #
 $IncludeConfig /etc/rsyslog.d/*.conf

--- a/builder/assets/rsysrot.sh
+++ b/builder/assets/rsysrot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+LOG_FILE=$1
+mv -f ${LOG_FILE} ${LOG_FILE}.1

--- a/builder/image-build.sh
+++ b/builder/image-build.sh
@@ -97,6 +97,7 @@ done
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/monkey' '/root/'
 # rsyslog config
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/rsyslog.conf' '/etc'
+${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/rsysrot.sh' '/etc/rsyslog.d'
 # Butterfly
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/butterfly.service' '/lib/systemd/system/'
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/butterfly.socket' '/lib/systemd/system/'

--- a/builder/image-build.sh
+++ b/builder/image-build.sh
@@ -95,7 +95,8 @@ done
 
 # Monkey
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/monkey' '/root/'
-
+# rsyslog config
+${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/rsyslog.conf' '/etc'
 # Butterfly
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/butterfly.service' '/lib/systemd/system/'
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/butterfly.socket' '/lib/systemd/system/'


### PR DESCRIPTION
Note: `rsyslog` is not very well documented and these changes may very well be incorrect. I could not replicate the `-` option for files (according to [a Server Fault answer](https://serverfault.com/questions/223148/does-the-sign-have-meaning-in-rsyslog-conf), it turns off syncing after logging - this is [referenced in the manual](https://www.rsyslog.com/doc/v8-stable/configuration/actions.html), but is very hard to find even if you know it's there). This may result in lots of writes and, eventually, a dead SD card.

Another thing I could not manage to do is automatic log rotation - `logrotate` invocation does not work for some reason (`rm` does, so it's not exactly an issue with `rsyslog`).