### PR TITLE
clever/rc: Allow disabling GCS thread

### DIFF
--- a/clever/launch/clever.launch
+++ b/clever/launch/clever.launch
@@ -71,5 +71,8 @@
     <include file="$(find clever)/launch/led.launch" if="$(arg led)"/>
 
     <!-- rc backend -->
-    <node name="rc" pkg="clever" type="rc" output="screen" if="$(arg rc)"/>
+    <node name="rc" pkg="clever" type="rc" output="screen" if="$(arg rc)" clear_params="true">
+        <!-- Send fake GCS heartbeats. Set to "true" for upstream PX4 -->
+        <param name="use_fake_gcs" value="false"/>
+    </node>
 </launch>

--- a/clever/src/rc.cpp
+++ b/clever/src/rc.cpp
@@ -39,8 +39,7 @@ public:
 		std::thread t(&RC::socketThread, this);
 		t.detach();
 
-		if (use_fake_gcs)
-		{
+		if (use_fake_gcs) {
 			std::thread gcst(&RC::fakeGCSThread, this);
 			gcst.detach();
 		}

--- a/clever/src/rc.cpp
+++ b/clever/src/rc.cpp
@@ -34,12 +34,16 @@ public:
 		nh(),
 		nh_priv("~")
 	{
+		bool use_fake_gcs = nh_priv.param("use_fake_gcs", true);
 		// Create socket thread
 		std::thread t(&RC::socketThread, this);
 		t.detach();
 
-		std::thread gcst(&RC::fakeGCSThread, this);
-		gcst.detach();
+		if (use_fake_gcs)
+		{
+			std::thread gcst(&RC::fakeGCSThread, this);
+			gcst.detach();
+		}
 
 		initLatchedState();
 	}


### PR DESCRIPTION
Currently spawning GCS thread results in ROS TCP errors. This patch allows a user to turn off this thread if it's not required.

The thread is turned off by default, since it's not required for our PX4 firmware.