### PR TITLE
Don't show spurious ssid during first boot

### DIFF
--- a/builder/assets/init_rpi.sh
+++ b/builder/assets/init_rpi.sh
@@ -37,7 +37,19 @@ echo_stamp() {
 
 NEW_SSID='clover-'$(head -c 100 /dev/urandom | xxd -ps -c 100 | sed -e "s/[^0-9]//g" | cut -c 1-4)
 echo_stamp "Setting SSID to ${NEW_SSID}"
-sudo sed -i.OLD "s/clover/${NEW_SSID}/" /etc/wpa_supplicant/wpa_supplicant.conf
+# TODO: Use wpa_cli insted direct file edit
+cat << EOF >> /etc/wpa_supplicant/wpa_supplicant.conf
+network={
+    ssid="${NEW_SSID}"
+    psk="cloverwifi"
+    mode=2
+    proto=WPA RSN
+    key_mgmt=WPA-PSK
+    pairwise=CCMP
+    group=CCMP
+    auth_alg=OPEN
+}
+EOF
 
 NEW_HOSTNAME=$(echo ${NEW_SSID} | tr '[:upper:]' '[:lower:]')
 echo_stamp "Setting hostname to $NEW_HOSTNAME"

--- a/builder/image-network.sh
+++ b/builder/image-network.sh
@@ -34,30 +34,14 @@ echo_stamp() {
   echo -e ${TEXT}
 }
 
-echo_stamp "#1 Write to /etc/wpa_supplicant/wpa_supplicant.conf"
-
-# TODO: Use wpa_cli insted direct file edit
-cat << EOF >> /etc/wpa_supplicant/wpa_supplicant.conf
-network={
-    ssid="clover"
-    psk="cloverwifi"
-    mode=2
-    proto=WPA RSN
-    key_mgmt=WPA-PSK
-    pairwise=CCMP
-    group=CCMP
-    auth_alg=OPEN
-}
-EOF
-
-echo_stamp "#2 Write STATIC to /etc/dhcpcd.conf"
+echo_stamp "#1 Write STATIC to /etc/dhcpcd.conf"
 
 cat << EOF >> /etc/dhcpcd.conf
 interface wlan0
 static ip_address=192.168.11.1/24
 EOF
 
-echo_stamp "#3 Write dhcp-config to /etc/dnsmasq.conf"
+echo_stamp "#2 Write dhcp-config to /etc/dnsmasq.conf"
 
 cat << EOF >> /etc/dnsmasq.conf
 interface=wlan0
@@ -70,4 +54,4 @@ domain-needed
 quiet-dhcp6
 EOF
 
-echo_stamp "#5 End of network installation"
+echo_stamp "#3 End of network installation"


### PR DESCRIPTION
Move initial wpa_supplicant configuration to init_rpi.sh script, effectively hiding the "ID-less" clover access point.