### PR TITLE
builder: Install ptvsd by default

### DIFF
--- a/builder/image-software.sh
+++ b/builder/image-software.sh
@@ -153,6 +153,10 @@ cp -R node-v10.15.0-linux-armv6l/* /usr/local/
 rm -rf node-v10.15.0-linux-armv6l/
 rm node-v10.15.0-linux-armv6l.tar.gz
 
+echo_stamp "Installing ptvsd"
+my_travis_retry pip install ptvsd
+my_travis_retry pip3 install ptvsd
+
 echo_stamp "Add .vimrc"
 cat << EOF > /home/pi/.vimrc
 set mouse-=a

--- a/builder/test/tests.sh
+++ b/builder/test/tests.sh
@@ -12,6 +12,10 @@ python3 --version
 ipython --version
 ipython3 --version
 
+# ptvsd does not have a stand-alone binary
+python -m ptvsd --version
+python3 -m ptvsd --version
+
 node -v
 npm -v
 


### PR DESCRIPTION
`ptvsd` provides a debugging interface for Visual Studio Code for Python. Our users would probably benefit from having this by default.

I will add an article about setting up a debugger in a separate P/R.